### PR TITLE
Change service config block to TypeList with MaxItems of 1

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,12 +20,12 @@ type Initialisation interface {
 }
 
 // GetServiceSettingsMap helper function for use by client code in NewClient instances
-// This function takes the schema.ResourceData passed in to NewClient, gets the *schema.Set
-// at the key passed in, converts to a list which we know will have just one element,
-// gets that element and converts to map[string]interface{}.  This map holds the
-// settings for the service.  If the block hasn't been set we return an error.
+// This function takes the schema.ResourceData passed in to NewClient, gets the []interface{}
+// at the key passed in which we know will have just one element,gets that element and
+// converts to map[string]interface{}.  This map holds the settings for the service.
+// If the block hasn't been set we return an error.
 func GetServiceSettingsMap(key string, r *schema.ResourceData) (map[string]interface{}, error) {
-	l := r.Get(key).(*schema.Set).List()
+	l := r.Get(key).([]interface{})
 	if len(l) == 0 {
 		return nil, fmt.Errorf("service %s block not defined in hpegl stanza", key)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -48,7 +48,7 @@ func NewProviderFunc(reg []registration.ServiceRegistration, pf ConfigureFunc) p
 				if _, ok := providerSchema[service.Name()]; ok {
 					panic(fmt.Sprintf("service name %s is repeated", service.Name()))
 				}
-				providerSchema[service.Name()] = convertToTypeSet(service.ProviderSchemaEntry())
+				providerSchema[service.Name()] = convertToTypeList(service.ProviderSchemaEntry())
 			}
 		}
 
@@ -117,13 +117,17 @@ func ServiceRegistrationSlice(reg registration.ServiceRegistration) []registrati
 	return []registration.ServiceRegistration{reg}
 }
 
-// convertToTypeSet helper function to take the *schema.Resource for a service and convert
-// it into the element type of a TypeSet with exactly one element
-func convertToTypeSet(r *schema.Resource) *schema.Schema {
+// convertToTypeList helper function to take the *schema.Resource for a service and convert
+// it into the element type of a TypeList with exactly one element
+// TODO the V2 SDK doesn't (yet) support TypeMap with Elem *Resource with nested maps
+// This is the currently recommended work-around. See
+// https://github.com/hashicorp/terraform-plugin-sdk/issues/155
+// https://github.com/hashicorp/terraform-plugin-sdk/issues/616
+func convertToTypeList(r *schema.Resource) *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
-		// Note that we only allow one of these sets, this is very important
+		// Note that we only allow one element in the list, this is very important
 		MaxItems: 1,
 		// We put the *schema.Resource here
 		Elem: r,


### PR DESCRIPTION
Currently the Terraform SDK doesn't support the use of TypeSet with
elements that have nested configuration blocks:
https://github.com/hashicorp/terraform-plugin-sdk/issues/616

The workaround is to instead use a TypeList with a MaxItems of 1.  We've
changed convertToTypeSet to convertToTypeList and made this change.
We've also had to modify client.GetServiceSettingsMap to expect a
[]interface{} as opposed to *schema.TypeSet

We've added a TODO about this so that when the SDK supports nested
resources in TypeSet then we can revert to TypeSet.