### PR TITLE
Remove iam-token provider variable and other changes

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -52,47 +52,33 @@ func NewProviderFunc(reg []registration.ServiceRegistration, pf ConfigureFunc) p
 			}
 		}
 
-		// TODO this needs to be removed
-		providerSchema["iam_token"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_TOKEN", ""),
-			Description: "The IAM token to be used with the client(s)",
-		}
-
 		providerSchema["iam_service_url"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_SERVICE_URL", "https://client.greenlake.hpe.com/api/iam"),
-			Description: "The IAM service URL to be used to generate tokens, defaults to production GLC",
+			Description: `The IAM service URL to be used to generate tokens, defaults to production GLC,
+				can be set by HPEGL_IAM_SERVICE_URL env-var`,
 		}
 
 		providerSchema["tenant_id"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("HPEGL_TENANT_ID", ""),
-			Description: "The tenant-id to be used",
+			Description: "The tenant-id to be used, can be set by HPEGL_TENANT_ID env-var",
 		}
 
 		providerSchema["user_id"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("HPEGL_USER_ID", ""),
-			Description: "The user id to be used",
+			Description: "The user id to be used, can be set by HPEGL_USER_ID env-var",
 		}
 
 		providerSchema["user_secret"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("HPEGL_USER_SECRET", ""),
-			Description: "The user secret to be used",
-		}
-
-		providerSchema["bmaas_resources_available"] = &schema.Schema{
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Toggle bmaas provider client and resource creation, this will require a .gltform file",
+			Description: "The user secret to be used, can be set by HPEGL_USER_SECRET env-var",
 		}
 
 		p := schema.Provider{


### PR DESCRIPTION
In this PR we make some changes to provider.go:
- we remove the iam-token variable
- we add text to the token generation variables to indicate the env-vars
  that can be used for them
- we've removed bmaas_resources_available for now, we will need to
  either add it back in when we reintegrate bmaas or else figure out how
  to get rid of it

These changes are for the first public release of the terraform
provider.