### PR TITLE
Add retry if status code is 429 Too Many Requests

### DIFF
--- a/pkg/token/issuertoken/issuertoken.go
+++ b/pkg/token/issuertoken/issuertoken.go
@@ -8,8 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hpe-hcss/errors/pkg/errors"
+)
+
+const (
+	retryLimit = 3
 )
 
 type TokenResponse struct {
@@ -29,12 +34,17 @@ func doRetries(call func() (*http.Response, error), retries int) (*http.Response
 			return nil, err
 		}
 
-		if resp.StatusCode != http.StatusInternalServerError || retries == 0 {
+		if !isStatusRetryable(resp.StatusCode) || retries == 0 {
 			break
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			time.Sleep(3 * time.Second)
 		}
 
 		retries--
 	}
+
 	return resp, nil
 }
 
@@ -54,7 +64,7 @@ func GenerateIssuerToken(ctx context.Context, issuerURL, clientID, clientSecret 
 
 	resp, err := doRetries(func() (*http.Response, error) {
 		return http.DefaultClient.Do(req)
-	}, 1)
+	}, retryLimit)
 	if err != nil {
 		return "", err
 	}
@@ -102,4 +112,12 @@ func GenerateIssuerToken(ctx context.Context, issuerURL, clientID, clientSecret 
 	}
 
 	return token.AccessToken, nil
+}
+
+func isStatusRetryable(statusCode int) bool {
+	if statusCode == http.StatusInternalServerError || statusCode == http.StatusTooManyRequests {
+		return true
+	}
+
+	return false
 }

--- a/pkg/token/issuertoken/issuertoken.go
+++ b/pkg/token/issuertoken/issuertoken.go
@@ -38,10 +38,7 @@ func doRetries(call func() (*http.Response, error), retries int) (*http.Response
 			break
 		}
 
-		if resp.StatusCode == http.StatusTooManyRequests {
-			time.Sleep(3 * time.Second)
-		}
-
+		time.Sleep(3 * time.Second)
 		retries--
 	}
 


### PR DESCRIPTION
Adds a retry if "issuer" endpoint returns a Too Many Requests(429) status code and sleeps for 3 seconds before retrying.
