### PR TITLE
Gltform package changes

### DIFF
--- a/pkg/gltform/gltform.go
+++ b/pkg/gltform/gltform.go
@@ -41,11 +41,11 @@ func GetGLConfig() (gljwt *Gljwt, err error) {
 	return gljwt, err
 }
 
-// WriteGLConfigLocally takes a map[string]interface{} which will normally come from a
+// WriteGLConfig takes a map[string]interface{} which will normally come from a
 // service block in the provider stanza and writes out a .gltform file in the directory
-// from which terraform is being run.  See the use of this function for bmaas in
-// terraform-provider-hpegl.
-func WriteGLConfigLocally(d map[string]interface{}) error {
+// from which terraform is being run and in the home directory.  See the use of this function
+// for bmaas in terraform-provider-hpegl.
+func WriteGLConfig(d map[string]interface{}) error {
 	config := &Gljwt{
 		// If space_name isn't present, we'll just write out ""
 		SpaceName: d["space_name"].(string),
@@ -59,9 +59,22 @@ func WriteGLConfigLocally(d map[string]interface{}) error {
 		return err
 	}
 
-	// Write out marshalled config into local .gltform
+	// Write out marshalled config into .gltform
+	homeDir, _ := os.UserHomeDir()
 	workingDir, _ := os.Getwd()
-	f, err := os.Create(filepath.Clean(filepath.Join(workingDir, fileExtension)))
+
+	for _, p := range []string{homeDir, workingDir} {
+		err = writeGLConfigToFile(b, p)
+		if err != nil {
+			break
+		}
+	}
+
+	return err
+}
+
+func writeGLConfigToFile(b []byte, dir string) error {
+	f, err := os.Create(filepath.Clean(filepath.Join(dir, fileExtension)))
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -73,15 +73,17 @@ func Schema() map[string]*schema.Schema {
 		Type:        schema.TypeString,
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_SERVICE_URL", "https://client.greenlake.hpe.com/api/iam"),
-		Description: `The IAM service URL to be used to generate tokens, defaults to production GLC,
-			can be set by HPEGL_IAM_SERVICE_URL env-var`,
+		Description: `The IAM service URL to be used to generate tokens.  In the case of API-vended service clients
+            (the default) then this should be set to the "issuer url" for the client.  In the case of non-API-vended
+            service clients use the appropriate GL "client" URL. Can be set by HPEGL_IAM_SERVICE_URL env-var`,
 	}
 
 	providerSchema["api_vended_service_client"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("HPEGL_API_VENDED_SERVICE_CLIENT", true),
-		Description: ``,
+		Description: `Declare if the service-client being used is an API-vended one or not.  Defaults to "true"
+            i.e. the client is API-vended.  The value can be set using the HPEGL_API_VENDED_SERVICE_CLIENT env-var.`,
 	}
 
 	providerSchema["tenant_id"] = &schema.Schema{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,7 +4,7 @@ package utils
 
 import (
 	"os"
-		
+
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
In this PR we rework the WriteGLConfigLocally so that it writes the
.gltform file in both the home directory and the local directory.  This
is to make sure that there is no confusion as to mismatched gltform
contents.  We rename the function WriteGLConfig.

We also change the Description fields for a couple of hpegl inputs.