### PR TITLE
Some more gltform changes

### DIFF
--- a/pkg/gltform/gltform.go
+++ b/pkg/gltform/gltform.go
@@ -31,7 +31,7 @@ type Gljwt struct {
 func GetGLConfig() (gljwt *Gljwt, err error) {
 	homeDir, _ := os.UserHomeDir()
 	workingDir, _ := os.Getwd()
-	for _, p := range []string{homeDir, workingDir} {
+	for _, p := range []string{workingDir, homeDir} {
 		gljwt, err = loadGLConfig(p)
 		if err == nil {
 			break
@@ -43,7 +43,7 @@ func GetGLConfig() (gljwt *Gljwt, err error) {
 
 // WriteGLConfig takes a map[string]interface{} which will normally come from a
 // service block in the provider stanza and writes out a .gltform file in the directory
-// from which terraform is being run and in the home directory.  See the use of this function
+// from which terraform is being run.  See the use of this function
 // for bmaas in terraform-provider-hpegl.
 func WriteGLConfig(d map[string]interface{}) error {
 	config := &Gljwt{
@@ -60,10 +60,9 @@ func WriteGLConfig(d map[string]interface{}) error {
 	}
 
 	// Write out marshalled config into .gltform
-	homeDir, _ := os.UserHomeDir()
 	workingDir, _ := os.Getwd()
 
-	for _, p := range []string{homeDir, workingDir} {
+	for _, p := range []string{workingDir} {
 		err = writeGLConfigToFile(b, p)
 		if err != nil {
 			break


### PR DESCRIPTION
In this PR we make some more gltform changes, in light of some hpegl
testing.  At present WriteGLConfig writes the .gltform file in home and
in the cwd.  GetGLConfig then looks for the .gltform file first in home
and then in the cwd.  The issue is that if you run hpegl with a bmaas
stanza and then subsequently without a bmaas stanza then hpegl will try
to initialise bmaas because it finds a .gltform in home.  This is not very
nice from a usability perspective.  This PR changes things so that
WriteGLConfig writes a .gltform only in the cwd.  Also GetGLConfig looks
first in cwd and then in home.  This means that what we expect to be the
most common use-case of a user specifying the .gltform contents in the
hpegl bmaas stanza will behave in a "friendly" way with no unexpected
attempts to initialise bmaas.