### PR TITLE
Add simple github dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  registries: []
+  schedule:
+    interval: daily


### PR DESCRIPTION
In this PR we add a simple github dependabot file that will only check
for updates to go.mod.