### PR TITLE
Replace identity-client token generation by identitytoken REST client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 vendor/
 bin/
 build/

--- a/pkg/token/identitytoken/identitytoken.go
+++ b/pkg/token/identitytoken/identitytoken.go
@@ -1,0 +1,156 @@
+package identitytoken
+
+import (
+        "context"
+        "encoding/json"
+        "fmt"
+        "io/ioutil"
+        "net/http"
+        "strings"
+        "time"
+
+        "github.com/hpe-hcss/errors/pkg/errors"
+)
+
+const (
+        retryLimit = 3
+)
+
+type GenerateTokenInput struct {
+        TenantID     string `json:"tenant_id"`
+        ClientID     string `json:"client_id"`
+        ClientSecret string `json:"client_secret"`
+        GrantType    string `json:"grant_type"`
+}
+
+type TokenResponse struct {
+        TokenType       string    `json:"token_type"`
+        AccessToken     string    `json:"access_token"`
+        RefreshToken    string    `json:"refresh_token"`
+        Expiry          time.Time `json:"expiry"`
+        ExpiresIn       int       `json:"expires_in"`
+        Scope           string    `json:"scope"`
+        AccessTokenOnly bool      `json:"accessTokenOnly"`
+}
+
+type Client struct {
+        identityServiceURL string
+        httpClient         httpClient
+}
+
+type httpClient interface {
+        Do(req *http.Request) (*http.Response, error)
+}
+
+// New creates a new identity Client object
+func New(identityServiceURL string) *Client {
+        client := &http.Client{Timeout: 10 * time.Second}
+        identityServiceURL = strings.TrimRight(identityServiceURL, "/")
+        return &Client{
+                identityServiceURL: identityServiceURL,
+                httpClient:         client,
+        }
+}
+
+func doRetries(call func() (*http.Response, error), retries int) (*http.Response, error) {
+        var resp *http.Response
+        var err error
+
+        for {
+                resp, err = call()
+                if err != nil {
+                        return nil, err
+                }
+
+                if !isStatusRetryable(resp.StatusCode) || retries == 0 {
+                        break
+                }
+
+                time.Sleep(3 * time.Second)
+                retries--
+        }
+
+        return resp, nil
+}
+
+func (c *Client) GenerateToken(ctx context.Context, tenantID, clientID, clientSecret string) (string, error) {
+        params := GenerateTokenInput{
+                TenantID:     tenantID,
+                ClientID:     clientID,
+                ClientSecret: clientSecret,
+                GrantType:    "client_credentials",
+        }
+
+        url := fmt.Sprintf("%s/v1/token", c.identityServiceURL)
+
+        b, err := json.Marshal(params)
+        if err != nil {
+                return "", err
+        }
+
+        req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(b)))
+
+        if err != nil {
+                return "", err
+        }
+        req.Header.Set("Content-Type", "application/json")
+
+        resp, err := doRetries(func() (*http.Response, error) {
+                return c.httpClient.Do(req)
+        }, retryLimit)
+        if err != nil {
+                return "", err
+        }
+        defer resp.Body.Close()
+
+        switch resp.StatusCode {
+        case http.StatusOK:
+                break
+        case http.StatusBadRequest:
+                body, err := ioutil.ReadAll(resp.Body)
+                if err != nil {
+                        return "", err
+                }
+                msg := fmt.Sprintf("Bad request: %v", string(body))
+                err = errors.MakeErrBadRequest(errors.ErrorResponse{
+                        ErrorCode: "ErrGenerateTokenBadRequest",
+                        Message:   msg,
+                })
+
+                return "", err
+        case http.StatusUnauthorized, http.StatusForbidden:
+                err = errors.MakeErrForbidden(clientID)
+
+                return "", err
+        default:
+                msg := fmt.Sprintf("Unexpected status code %v", resp.StatusCode)
+                err = errors.MakeErrInternalError(errors.ErrorResponse{
+                        ErrorCode: "ErrGenerateTokenUnexpectedResponseCode",
+                        Message:   msg,
+                })
+
+                return "", err
+        }
+
+        body, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+                return "", err
+        }
+
+        var token TokenResponse
+
+        err = json.Unmarshal(body, &token)
+        if err != nil {
+                return "", err
+        }
+
+        return token.AccessToken, nil
+}
+
+func isStatusRetryable(statusCode int) bool {
+        if statusCode == http.StatusInternalServerError || statusCode == http.StatusTooManyRequests {
+                return true
+        }
+
+        return false
+}

--- a/pkg/token/identitytoken/identitytoken.go
+++ b/pkg/token/identitytoken/identitytoken.go
@@ -1,156 +1,160 @@
 package identitytoken
 
 import (
-        "context"
-        "encoding/json"
-        "fmt"
-        "io/ioutil"
-        "net/http"
-        "strings"
-        "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
 
-        "github.com/hpe-hcss/errors/pkg/errors"
+	"github.com/hpe-hcss/errors/pkg/errors"
 )
 
 const (
-        retryLimit = 3
+	retryLimit = 3
 )
 
 type GenerateTokenInput struct {
-        TenantID     string `json:"tenant_id"`
-        ClientID     string `json:"client_id"`
-        ClientSecret string `json:"client_secret"`
-        GrantType    string `json:"grant_type"`
+	TenantID     string `json:"tenant_id"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	GrantType    string `json:"grant_type"`
 }
 
 type TokenResponse struct {
-        TokenType       string    `json:"token_type"`
-        AccessToken     string    `json:"access_token"`
-        RefreshToken    string    `json:"refresh_token"`
-        Expiry          time.Time `json:"expiry"`
-        ExpiresIn       int       `json:"expires_in"`
-        Scope           string    `json:"scope"`
-        AccessTokenOnly bool      `json:"accessTokenOnly"`
+	TokenType       string    `json:"token_type"`
+	AccessToken     string    `json:"access_token"`
+	RefreshToken    string    `json:"refresh_token"`
+	Expiry          time.Time `json:"expiry"`
+	ExpiresIn       int       `json:"expires_in"`
+	Scope           string    `json:"scope"`
+	AccessTokenOnly bool      `json:"accessTokenOnly"`
 }
 
 type Client struct {
-        identityServiceURL string
-        httpClient         httpClient
+	identityServiceURL string
+	httpClient         httpClient
 }
 
 type httpClient interface {
-        Do(req *http.Request) (*http.Response, error)
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // New creates a new identity Client object
 func New(identityServiceURL string) *Client {
-        client := &http.Client{Timeout: 10 * time.Second}
-        identityServiceURL = strings.TrimRight(identityServiceURL, "/")
-        return &Client{
-                identityServiceURL: identityServiceURL,
-                httpClient:         client,
-        }
+	client := &http.Client{Timeout: 10 * time.Second}
+	identityServiceURL = strings.TrimRight(identityServiceURL, "/")
+	return &Client{
+		identityServiceURL: identityServiceURL,
+		httpClient:         client,
+	}
 }
 
 func doRetries(call func() (*http.Response, error), retries int) (*http.Response, error) {
-        var resp *http.Response
-        var err error
+	var resp *http.Response
+	var err error
 
-        for {
-                resp, err = call()
-                if err != nil {
-                        return nil, err
-                }
+	for {
+		resp, err = call()
+		if err != nil {
+			return nil, err
+		}
 
-                if !isStatusRetryable(resp.StatusCode) || retries == 0 {
-                        break
-                }
+		if !isStatusRetryable(resp.StatusCode) || retries == 0 {
+			break
+		}
 
-                time.Sleep(3 * time.Second)
-                retries--
-        }
+		time.Sleep(3 * time.Second)
+		retries--
+	}
 
-        return resp, nil
+	return resp, nil
 }
 
 func (c *Client) GenerateToken(ctx context.Context, tenantID, clientID, clientSecret string) (string, error) {
-        params := GenerateTokenInput{
-                TenantID:     tenantID,
-                ClientID:     clientID,
-                ClientSecret: clientSecret,
-                GrantType:    "client_credentials",
-        }
+	params := GenerateTokenInput{
+		TenantID:     tenantID,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		GrantType:    "client_credentials",
+	}
 
-        url := fmt.Sprintf("%s/v1/token", c.identityServiceURL)
+	url := fmt.Sprintf("%s/v1/token", c.identityServiceURL)
 
-        b, err := json.Marshal(params)
-        if err != nil {
-                return "", err
-        }
+	b, err := json.Marshal(params)
+	if err != nil {
+		return "", err
+	}
 
-        req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(b)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(b)))
 
-        if err != nil {
-                return "", err
-        }
-        req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
 
-        resp, err := doRetries(func() (*http.Response, error) {
-                return c.httpClient.Do(req)
-        }, retryLimit)
-        if err != nil {
-                return "", err
-        }
-        defer resp.Body.Close()
+	resp, err := doRetries(func() (*http.Response, error) {
+		return c.httpClient.Do(req)
+	}, retryLimit)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
 
-        switch resp.StatusCode {
-        case http.StatusOK:
-                break
-        case http.StatusBadRequest:
-                body, err := ioutil.ReadAll(resp.Body)
-                if err != nil {
-                        return "", err
-                }
-                msg := fmt.Sprintf("Bad request: %v", string(body))
-                err = errors.MakeErrBadRequest(errors.ErrorResponse{
-                        ErrorCode: "ErrGenerateTokenBadRequest",
-                        Message:   msg,
-                })
+	switch resp.StatusCode {
+	case http.StatusOK:
+		break
+	case http.StatusBadRequest:
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		msg := fmt.Sprintf("Bad request: %v", string(body))
+		err = errors.MakeErrBadRequest(errors.ErrorResponse{
+			ErrorCode: "ErrGenerateTokenBadRequest",
+			Message:   msg,
+		})
 
-                return "", err
-        case http.StatusUnauthorized, http.StatusForbidden:
-                err = errors.MakeErrForbidden(clientID)
+		return "", err
+	case http.StatusForbidden:
+		err = errors.MakeErrForbidden(clientID)
 
-                return "", err
-        default:
-                msg := fmt.Sprintf("Unexpected status code %v", resp.StatusCode)
-                err = errors.MakeErrInternalError(errors.ErrorResponse{
-                        ErrorCode: "ErrGenerateTokenUnexpectedResponseCode",
-                        Message:   msg,
-                })
+		return "", err
+	case http.StatusUnauthorized:
+		err = errors.MakeErrUnauthorized(clientID)
 
-                return "", err
-        }
+		return "", err
+	default:
+		msg := fmt.Sprintf("Unexpected status code %v", resp.StatusCode)
+		err = errors.MakeErrInternalError(errors.ErrorResponse{
+			ErrorCode: "ErrGenerateTokenUnexpectedResponseCode",
+			Message:   msg,
+		})
 
-        body, err := ioutil.ReadAll(resp.Body)
-        if err != nil {
-                return "", err
-        }
+		return "", err
+	}
 
-        var token TokenResponse
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
 
-        err = json.Unmarshal(body, &token)
-        if err != nil {
-                return "", err
-        }
+	var token TokenResponse
 
-        return token.AccessToken, nil
+	err = json.Unmarshal(body, &token)
+	if err != nil {
+		return "", err
+	}
+
+	return token.AccessToken, nil
 }
 
 func isStatusRetryable(statusCode int) bool {
-        if statusCode == http.StatusInternalServerError || statusCode == http.StatusTooManyRequests {
-                return true
-        }
+	if statusCode == http.StatusInternalServerError || statusCode == http.StatusTooManyRequests {
+		return true
+	}
 
-        return false
+	return false
 }

--- a/pkg/token/identitytoken/identitytoken_test.go
+++ b/pkg/token/identitytoken/identitytoken_test.go
@@ -1,190 +1,197 @@
 package identitytoken
 
 import (
-        "context"
-        "encoding/json"
-        "errors"
-        "io"
-        "net/http"
-        "testing"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
 
-        "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // nolint: tparallel
 func TestDoRetries(t *testing.T) {
-        t.Parallel()
-        totalRetries := 0
-        testcases := []struct {
-                name           string
-                call           func() (*http.Response, error)
-                responseStatus int
-                err            error
-        }{
-                {
-                        name: "status 500",
-                        call: func() (*http.Response, error) {
-                                totalRetries++
+	t.Parallel()
+	totalRetries := 0
+	testcases := []struct {
+		name           string
+		call           func() (*http.Response, error)
+		responseStatus int
+		err            error
+	}{
+		{
+			name: "status 500",
+			call: func() (*http.Response, error) {
+				totalRetries++
 
-                                return &http.Response{StatusCode: http.StatusInternalServerError}, nil
-                        },
-                        responseStatus: http.StatusInternalServerError,
-                },
-                {
-                        name: "status 429",
-                        call: func() (*http.Response, error) {
-                                totalRetries++
+				return &http.Response{StatusCode: http.StatusInternalServerError}, nil
+			},
+			responseStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "status 429",
+			call: func() (*http.Response, error) {
+				totalRetries++
 
-                                return &http.Response{StatusCode: http.StatusTooManyRequests}, nil
-                        },
-                        responseStatus: http.StatusTooManyRequests,
-                },
-                {
-                        name: "status 502 no retry",
-                        call: func() (*http.Response, error) {
-                                totalRetries++
+				return &http.Response{StatusCode: http.StatusTooManyRequests}, nil
+			},
+			responseStatus: http.StatusTooManyRequests,
+		},
+		{
+			name: "status 502 no retry",
+			call: func() (*http.Response, error) {
+				totalRetries++
 
-                                return &http.Response{StatusCode: http.StatusBadGateway}, nil
-                        },
-                        responseStatus: http.StatusBadGateway,
-                },
-                {
-                        name: "no url",
-                        call: func() (*http.Response, error) {
-                                return nil, errors.New("http: nil Request.URL")
-                        },
-                        err: errors.New("http: nil Request.URL"),
-                },
-        }
+				return &http.Response{StatusCode: http.StatusBadGateway}, nil
+			},
+			responseStatus: http.StatusBadGateway,
+		},
+		{
+			name: "no url",
+			call: func() (*http.Response, error) {
+				return nil, errors.New("http: nil Request.URL")
+			},
+			err: errors.New("http: nil Request.URL"),
+		},
+	}
 
-        for _, testcase := range testcases {
-                tc := testcase
-                t.Run(tc.name, func(t *testing.T) {
-                        resp, err := doRetries(tc.call, 1) // nolint: bodyclose
-                        if tc.err != nil {
-                                assert.EqualError(t, err, tc.err.Error())
-                        } else {
-                                assert.Equal(t, tc.responseStatus, resp.StatusCode)
+	for _, testcase := range testcases {
+		tc := testcase
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := doRetries(tc.call, 1) // nolint: bodyclose
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+			} else {
+				assert.Equal(t, tc.responseStatus, resp.StatusCode)
 
-                                // only 429 and 500 status codes should retry
-                                if tc.responseStatus == http.StatusBadGateway {
-                                        assert.Equal(t, 1, totalRetries)
-                                } else {
-                                        assert.Equal(t, 2, totalRetries)
-                                }
+				// only 429 and 500 status codes should retry
+				if tc.responseStatus == http.StatusBadGateway {
+					assert.Equal(t, 1, totalRetries)
+				} else {
+					assert.Equal(t, 2, totalRetries)
+				}
 
-                                totalRetries = 0
-                        }
-                })
-        }
+				totalRetries = 0
+			}
+		})
+	}
 }
 
 type testHTTPClient struct {
-        statusCode int
-        body       TokenResponse
+	statusCode int
+	body       TokenResponse
 }
 
 type bodyReadCloser struct {
-        body      []byte
-        readIndex int
+	body      []byte
+	readIndex int
 }
 
 func (b *bodyReadCloser) Close() error {
-        return nil
+	return nil
 }
 
 func (b *bodyReadCloser) Read(p []byte) (n int, err error) {
-        if b.readIndex >= len(b.body) {
-                err = io.EOF
+	if b.readIndex >= len(b.body) {
+		err = io.EOF
 
-                return
-        }
+		return
+	}
 
-        n = copy(p, b.body[b.readIndex:])
-        b.readIndex += n
+	n = copy(p, b.body[b.readIndex:])
+	b.readIndex += n
 
-        return n, nil
+	return n, nil
 }
 
 func (h *testHTTPClient) Do(req *http.Request) (*http.Response, error) {
-        bytes, err := json.Marshal(h.body)
-        if err != nil {
-                return nil, err
-        }
+	bytes, err := json.Marshal(h.body)
+	if err != nil {
+		return nil, err
+	}
 
-        body := &bodyReadCloser{body: bytes}
+	body := &bodyReadCloser{body: bytes}
 
-        return &http.Response{StatusCode: h.statusCode, Body: body}, nil
+	return &http.Response{StatusCode: h.statusCode, Body: body}, nil
 }
 
 func createTestClient(identityServiceURL string, statusCode int, token TokenResponse) *Client {
-        c := New(identityServiceURL)
-        c.httpClient = &testHTTPClient{
-                statusCode: statusCode,
-                body:       token,
-        }
+	c := New(identityServiceURL)
+	c.httpClient = &testHTTPClient{
+		statusCode: statusCode,
+		body:       token,
+	}
 
-        return c
+	return c
 }
 
 func TestGenerateToken(t *testing.T) {
-        t.Parallel()
-        testcases := []struct {
-                name       string
-                ctx        context.Context
-                url        string
-                statusCode int
-                token      TokenResponse
-                err        error
-        }{
-                {
-                        name:       "success",
-                        ctx:        context.Background(),
-                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
-                        statusCode: http.StatusOK,
-                        token: TokenResponse{
-                                AccessToken: "access-token",
-                        },
-                },
-                {
-                        name:       "status code 404",
-                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
-                        ctx:        context.Background(),
-                        statusCode: http.StatusNotFound,
-                        err:        errors.New("Unexpected status code 404"),
-                },
-                {
-                        name: "no context",
-                        url:  "https://client.greenlake.hpe.com/api/iam/identity",
-                        ctx:  nil,
-                        err:  errors.New("net/http: nil Context"),
-                },
-                {
-                        name:       "status code 400",
-                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
-                        ctx:        context.Background(),
-                        statusCode: http.StatusBadRequest,
-                        err:        errors.New("Bad request: {\"token_type\":\"\",\"access_token\":\"\",\"refresh_token\":\"\",\"expiry\":\"0001-01-01T00:00:00Z\",\"expires_in\":0,\"scope\":\"\",\"accessTokenOnly\":false}"),
-                },
-                {
-                        name:       "status code 401",
-                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
-                        ctx:        context.Background(),
-                        statusCode: http.StatusUnauthorized,
-                        err:        errors.New("Forbidden: "),
-                },
-        }
+	t.Parallel()
+	testcases := []struct {
+		name       string
+		ctx        context.Context
+		url        string
+		statusCode int
+		token      TokenResponse
+		err        error
+	}{
+		{
+			name:       "success",
+			ctx:        context.Background(),
+			url:        "https://client.greenlake.hpe.com/api/iam/identity",
+			statusCode: http.StatusOK,
+			token: TokenResponse{
+				AccessToken: "access-token",
+			},
+		},
+		{
+			name:       "status code 404",
+			url:        "https://client.greenlake.hpe.com/api/iam/identity",
+			ctx:        context.Background(),
+			statusCode: http.StatusNotFound,
+			err:        errors.New("Unexpected status code 404"),
+		},
+		{
+			name: "no context",
+			url:  "https://client.greenlake.hpe.com/api/iam/identity",
+			ctx:  nil,
+			err:  errors.New("net/http: nil Context"),
+		},
+		{
+			name:       "status code 400",
+			url:        "https://client.greenlake.hpe.com/api/iam/identity",
+			ctx:        context.Background(),
+			statusCode: http.StatusBadRequest,
+			err:        errors.New("Bad request: {\"token_type\":\"\",\"access_token\":\"\",\"refresh_token\":\"\",\"expiry\":\"0001-01-01T00:00:00Z\",\"expires_in\":0,\"scope\":\"\",\"accessTokenOnly\":false}"),
+		},
+		{
+			name:       "status code 401",
+			url:        "https://client.greenlake.hpe.com/api/iam/identity",
+			ctx:        context.Background(),
+			statusCode: http.StatusUnauthorized,
+			err:        errors.New("Unauthorized access: "),
+		},
+		{
+			name:       "status code 403",
+			url:        "https://client.greenlake.hpe.com/api/iam/identity",
+			ctx:        context.Background(),
+			statusCode: http.StatusForbidden,
+			err:        errors.New("Forbidden: "),
+		},
+	}
 
-        for _, testcase := range testcases {
-                tc := testcase
+	for _, testcase := range testcases {
+		tc := testcase
 
-                c := createTestClient(tc.url, tc.statusCode, tc.token)
+		c := createTestClient(tc.url, tc.statusCode, tc.token)
 
-                token, err := c.GenerateToken(tc.ctx, "", "", "")
-                if tc.err != nil {
-                        assert.EqualError(t, err, tc.err.Error())
-                }
+		token, err := c.GenerateToken(tc.ctx, "", "", "")
+		if tc.err != nil {
+			assert.EqualError(t, err, tc.err.Error())
+		}
 
-                assert.Equal(t, tc.token.AccessToken, token)
-        }
+		assert.Equal(t, tc.token.AccessToken, token)
+	}
 }

--- a/pkg/token/identitytoken/identitytoken_test.go
+++ b/pkg/token/identitytoken/identitytoken_test.go
@@ -1,0 +1,190 @@
+package identitytoken
+
+import (
+        "context"
+        "encoding/json"
+        "errors"
+        "io"
+        "net/http"
+        "testing"
+
+        "github.com/stretchr/testify/assert"
+)
+
+// nolint: tparallel
+func TestDoRetries(t *testing.T) {
+        t.Parallel()
+        totalRetries := 0
+        testcases := []struct {
+                name           string
+                call           func() (*http.Response, error)
+                responseStatus int
+                err            error
+        }{
+                {
+                        name: "status 500",
+                        call: func() (*http.Response, error) {
+                                totalRetries++
+
+                                return &http.Response{StatusCode: http.StatusInternalServerError}, nil
+                        },
+                        responseStatus: http.StatusInternalServerError,
+                },
+                {
+                        name: "status 429",
+                        call: func() (*http.Response, error) {
+                                totalRetries++
+
+                                return &http.Response{StatusCode: http.StatusTooManyRequests}, nil
+                        },
+                        responseStatus: http.StatusTooManyRequests,
+                },
+                {
+                        name: "status 502 no retry",
+                        call: func() (*http.Response, error) {
+                                totalRetries++
+
+                                return &http.Response{StatusCode: http.StatusBadGateway}, nil
+                        },
+                        responseStatus: http.StatusBadGateway,
+                },
+                {
+                        name: "no url",
+                        call: func() (*http.Response, error) {
+                                return nil, errors.New("http: nil Request.URL")
+                        },
+                        err: errors.New("http: nil Request.URL"),
+                },
+        }
+
+        for _, testcase := range testcases {
+                tc := testcase
+                t.Run(tc.name, func(t *testing.T) {
+                        resp, err := doRetries(tc.call, 1) // nolint: bodyclose
+                        if tc.err != nil {
+                                assert.EqualError(t, err, tc.err.Error())
+                        } else {
+                                assert.Equal(t, tc.responseStatus, resp.StatusCode)
+
+                                // only 429 and 500 status codes should retry
+                                if tc.responseStatus == http.StatusBadGateway {
+                                        assert.Equal(t, 1, totalRetries)
+                                } else {
+                                        assert.Equal(t, 2, totalRetries)
+                                }
+
+                                totalRetries = 0
+                        }
+                })
+        }
+}
+
+type testHTTPClient struct {
+        statusCode int
+        body       TokenResponse
+}
+
+type bodyReadCloser struct {
+        body      []byte
+        readIndex int
+}
+
+func (b *bodyReadCloser) Close() error {
+        return nil
+}
+
+func (b *bodyReadCloser) Read(p []byte) (n int, err error) {
+        if b.readIndex >= len(b.body) {
+                err = io.EOF
+
+                return
+        }
+
+        n = copy(p, b.body[b.readIndex:])
+        b.readIndex += n
+
+        return n, nil
+}
+
+func (h *testHTTPClient) Do(req *http.Request) (*http.Response, error) {
+        bytes, err := json.Marshal(h.body)
+        if err != nil {
+                return nil, err
+        }
+
+        body := &bodyReadCloser{body: bytes}
+
+        return &http.Response{StatusCode: h.statusCode, Body: body}, nil
+}
+
+func createTestClient(identityServiceURL string, statusCode int, token TokenResponse) *Client {
+        c := New(identityServiceURL)
+        c.httpClient = &testHTTPClient{
+                statusCode: statusCode,
+                body:       token,
+        }
+
+        return c
+}
+
+func TestGenerateToken(t *testing.T) {
+        t.Parallel()
+        testcases := []struct {
+                name       string
+                ctx        context.Context
+                url        string
+                statusCode int
+                token      TokenResponse
+                err        error
+        }{
+                {
+                        name:       "success",
+                        ctx:        context.Background(),
+                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
+                        statusCode: http.StatusOK,
+                        token: TokenResponse{
+                                AccessToken: "access-token",
+                        },
+                },
+                {
+                        name:       "status code 404",
+                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
+                        ctx:        context.Background(),
+                        statusCode: http.StatusNotFound,
+                        err:        errors.New("Unexpected status code 404"),
+                },
+                {
+                        name: "no context",
+                        url:  "https://client.greenlake.hpe.com/api/iam/identity",
+                        ctx:  nil,
+                        err:  errors.New("net/http: nil Context"),
+                },
+                {
+                        name:       "status code 400",
+                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
+                        ctx:        context.Background(),
+                        statusCode: http.StatusBadRequest,
+                        err:        errors.New("Bad request: {\"token_type\":\"\",\"access_token\":\"\",\"refresh_token\":\"\",\"expiry\":\"0001-01-01T00:00:00Z\",\"expires_in\":0,\"scope\":\"\",\"accessTokenOnly\":false}"),
+                },
+                {
+                        name:       "status code 401",
+                        url:        "https://client.greenlake.hpe.com/api/iam/identity",
+                        ctx:        context.Background(),
+                        statusCode: http.StatusUnauthorized,
+                        err:        errors.New("Forbidden: "),
+                },
+        }
+
+        for _, testcase := range testcases {
+                tc := testcase
+
+                c := createTestClient(tc.url, tc.statusCode, tc.token)
+
+                token, err := c.GenerateToken(tc.ctx, "", "", "")
+                if tc.err != nil {
+                        assert.EqualError(t, err, tc.err.Error())
+                }
+
+                assert.Equal(t, tc.token.AccessToken, token)
+        }
+}

--- a/pkg/token/serviceclient/handler.go
+++ b/pkg/token/serviceclient/handler.go
@@ -13,6 +13,7 @@ import (
 	identityclient "github.com/hpe-hcss/iam-lib/pkg/identity-client"
 
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/token/common"
+	"github.com/hewlettpackard/hpegl-provider-lib/pkg/token/identitytoken"
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/token/issuertoken"
 )
 

--- a/pkg/token/serviceclient/handler.go
+++ b/pkg/token/serviceclient/handler.go
@@ -64,7 +64,7 @@ func NewHandler(d *schema.ResourceData, opts ...CreateOpt) (common.TokenChannelI
 	if h.vendedServiceClient {
 		h.client = issuertoken.New(h.iamServiceURL)
 	} else {
-		h.client = identityclient.New(h.iamServiceURL)
+		h.client = identitytoken.New(h.iamServiceURL)
 	}
 
 	// run overrides


### PR DESCRIPTION
Replace the identity-token GenerateToken call (iam-lib) by a Golang REST client called identitytoken to remove iam-lib dependency.
gofmt on identitytoken.go/identitytoken_test.go.