### PR TITLE
Allow pass-in of access tokens

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -69,6 +69,14 @@ func NewProviderFunc(reg []registration.ServiceRegistration, pf ConfigureFunc) p
 
 func Schema() map[string]*schema.Schema {
 	providerSchema := make(map[string]*schema.Schema)
+	providerSchema["iam_token"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_TOKEN", ""),
+		Description: `The IAM token to be used with the client(s).  Note that in normal operation
+                a service client is used.  Passing-in a token means that tokens will not be generated or refreshed.`,
+	}
+
 	providerSchema["iam_service_url"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,

--- a/pkg/token/httpclient/httpclient_test.go
+++ b/pkg/token/httpclient/httpclient_test.go
@@ -69,8 +69,8 @@ func (h *testHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: h.statusCode, Body: body}, nil
 }
 
-func createTestClient(identityServiceURL string, statusCode int, token interface{}, vendedServiceClient bool) *Client {
-	c := New(identityServiceURL, vendedServiceClient)
+func createTestClient(identityServiceURL, passedInToken string, statusCode int, token interface{}, vendedServiceClient bool) *Client {
+	c := New(identityServiceURL, vendedServiceClient, passedInToken)
 	if token == nil {
 		c.httpClient = &testHTTPClient{
 			statusCode: statusCode,
@@ -194,7 +194,7 @@ func TestGenerateToken(t *testing.T) {
 	for _, testcase := range issuertokentc {
 		tc := testcase
 
-		c = createTestClient(tc.url, tc.statusCode, tc.token, true)
+		c = createTestClient(tc.url, "", tc.statusCode, tc.token, true)
 
 		token, err := c.GenerateToken(tc.ctx, "", "", "")
 		if tc.err != nil {
@@ -208,7 +208,7 @@ func TestGenerateToken(t *testing.T) {
 	for _, testcase := range identitytokentc {
 		tc := testcase
 
-		c = createTestClient(tc.url, tc.statusCode, tc.token, false)
+		c = createTestClient(tc.url, "", tc.statusCode, tc.token, false)
 
 		token, err := c.GenerateToken(tc.ctx, "", "", "")
 		if tc.err != nil {
@@ -217,4 +217,13 @@ func TestGenerateToken(t *testing.T) {
 
 		assert.Equal(t, tc.token.AccessToken, token)
 	}
+}
+
+func TestGenerateTokenPassedInToken(t *testing.T) {
+	t.Parallel()
+	c := createTestClient("", "testToken", http.StatusAccepted, nil, true)
+
+	token, err := c.GenerateToken(context.Background(), "", "", "")
+	assert.Equal(t, "testToken", token)
+	assert.NoError(t, err)
 }

--- a/pkg/token/serviceclient/handler.go
+++ b/pkg/token/serviceclient/handler.go
@@ -60,7 +60,10 @@ func NewHandler(d *schema.ResourceData, opts ...CreateOpt) (common.TokenChannelI
 	h.clientSecret = d.Get("user_secret").(string)
 	h.vendedServiceClient = d.Get("api_vended_service_client").(bool)
 
-	h.client = httpc.New(h.iamServiceURL, h.vendedServiceClient)
+	// get passed-in token, if present
+	passedInToken := d.Get("iam_token").(string)
+
+	h.client = httpc.New(h.iamServiceURL, h.vendedServiceClient, passedInToken)
 
 	// run overrides
 	for _, opt := range opts {


### PR DESCRIPTION
In this PR we add the ability to pass-in an access token.  The access
token can be provided through the HPEGL_IAM_TOKEN env-var.  The changes:
- we add the iam_token input to provider.go
- we extract the value of iam_token in serviceclient/handler.go and pass
  it down to httpclient New
- we put the value in httpClient Client as passedInToken
- if passedInToken is not empty, the Client GenerateToken function
  returns it

We've amended unit-tests in light of this change and also added a simple
unit-test of the new functionality.