### PR TITLE
Adding CONTRIBUTING.md/DCO to repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contribution Guide 
+
+We welcome and encourage community contributions to hpegl-provider-lib.
+
+## Contributing
+
+The best way to directly collaborate with the project contributors is through GitHub: <https://github.com/HewlettPackard/hpegl-provider-lib>
+
+* If you want to contribute to our code by either fixing a problem or creating a new feature, please open a GitHub pull request.
+* If you want to raise an issue such as a defect, an enhancement request or a general issue, please open a GitHub issue.
+
+Before you start to code, we recommend discussing your plans through a GitHub issue, especially for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you feedback on your design, and help you find out if someone else is working on the same thing.
+
+Note that all patches from all contributors get reviewed.
+After a pull request is made, other contributors will offer feedback. If the patch passes review, a maintainer will accept it with a comment.
+When a pull request fails review, the author is expected to update the pull request to address the issue until it passes review and the pull request merges successfully.
+
+At least one review from a maintainer is required for all patches.
+
+### [Developer's Certificate of Origin](https://developercertificate.org/)
+
+All contributions must include acceptance of the DCO:
+
+>Developer Certificate of Origin
+>Version 1.1
+>
+>Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+>
+>Everyone is permitted to copy and distribute verbatim copies of this
+>license document, but changing it is not allowed.
+>
+>
+>Developer's Certificate of Origin 1.1
+>
+>By making a contribution to this project, I certify that:
+>
+>(a) The contribution was created in whole or in part by me and I
+>    have the right to submit it under the open source license
+>    indicated in the file; or
+>
+>(b) The contribution is based upon previous work that, to the best
+>    of my knowledge, is covered under an appropriate open source
+>    license and I have the right under that license to submit that
+>    work with modifications, whether created in whole or in part
+>    by me, under the same open source license (unless I am
+>    permitted to submit under a different license), as indicated
+>    in the file; or
+>
+>(c) The contribution was provided directly to me by some other
+>    person who certified (a), (b) or (c) and I have not modified
+>    it.
+>
+>(d) I understand and agree that this project and the contribution
+>    are public and that a record of the contribution (including all
+>    personal information I submit with it, including my sign-off) is
+>    maintained indefinitely and may be redistributed consistent with
+>    this project or the open source license(s) involved.
+
+### Sign your work
+
+To accept the DCO, simply add this line to each commit message with your
+name and email address (git commit -s will do this for you):
+
+    Signed-off-by: Jane Example <jane@example.com>
+
+For legal reasons, no anonymous or pseudonymous contributions are
+accepted.
+
+## Submitting Code Pull Requests
+
+We encourage and support contributions from the community. No fix is too
+small. We strive to process all pull requests as soon as possible and
+with constructive feedback. If your pull request is not accepted at
+first, please try again after addressing the feedback you received.
+
+To make a pull request you will need a GitHub account. For help, see
+GitHub's documentation on forking and pull requests.


### PR DESCRIPTION
Added CONTRIBUTING.md to make contributors aware of the Repo having a
DCO requirement, it's based on the DCO found in terraform-provider-oneview

This PR will also check that the DCO app added to the Org will pick up signed commits

Signed-off-by: J0HNB0Y <johnny.glynn@hpe.com>