### PR TITLE
Renaming service client to API client

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -74,23 +74,23 @@ func Schema() map[string]*schema.Schema {
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_TOKEN", ""),
 		Description: `The IAM token to be used with the client(s).  Note that in normal operation
-                a service client is used.  Passing-in a token means that tokens will not be generated or refreshed.`,
+                an API client is used.  Passing-in a token means that tokens will not be generated or refreshed.`,
 	}
 
 	providerSchema["iam_service_url"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_SERVICE_URL", "https://client.greenlake.hpe.com/api/iam"),
-		Description: `The IAM service URL to be used to generate tokens.  In the case of API-vended service clients
+		Description: `The IAM service URL to be used to generate tokens.  In the case of API-vended API clients
             (the default) then this should be set to the "issuer url" for the client.  In the case of non-API-vended
-            service clients use the appropriate GL "client" URL. Can be set by HPEGL_IAM_SERVICE_URL env-var`,
+            API clients use the appropriate GL "client" URL. Can be set by HPEGL_IAM_SERVICE_URL env-var`,
 	}
 
 	providerSchema["api_vended_service_client"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("HPEGL_API_VENDED_SERVICE_CLIENT", true),
-		Description: `Declare if the service-client being used is an API-vended one or not.  Defaults to "true"
+		Description: `Declare if the API client being used is an API-vended one or not.  Defaults to "true"
             i.e. the client is API-vended.  The value can be set using the HPEGL_API_VENDED_SERVICE_CLIENT env-var.`,
 	}
 


### PR DESCRIPTION
Changing from Service client to API client so the docs are correctly
generated

Signed-off-by: J0HNB0Y <johnny.glynn@hpe.com>