### PR TITLE
Remove internal IP address from token POST in k8s environments

### DIFF
--- a/pkg/token/issuertoken/issuertoken.go
+++ b/pkg/token/issuertoken/issuertoken.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 package issuertoken
 
@@ -50,7 +50,7 @@ func GenerateToken(
 		return httpClient.Do(req)
 	}, retryLimit)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("network error in post to get token")
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
When running the hpegl provider in k8s environments a bogus IAM Issuer URL in the supplied API client creds will result in the internal IP address of the running container being contained in the error message from the IAM POST command to retrieve a token.  This PR sanitises the relevant error message and removes the IP address.

Signed-off-by: Eamonn O'Toole <eamonn.otoole@hpe.com>