### PR TITLE
Update trivy workflow Github hosted runner

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-18.04` is no longer available.
Updating to `ubuntu-22.04`.
