### PR TITLE
Changes to support GLP IAM API Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hewlettpackard/hpegl-provider-lib
 go 1.18
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.43.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
@@ -36,6 +35,7 @@ require (
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348 // indirect
 	github.com/daixiang0/gci v0.9.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingajkin/go-header v0.4.2 // indirect
 	github.com/esimonov/ifshort v1.0.4 // indirect
 	github.com/ettle/strcase v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hewlettpackard/hpegl-provider-lib
 go 1.18
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.43.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
@@ -35,7 +36,6 @@ require (
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348 // indirect
 	github.com/daixiang0/gci v0.9.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingajkin/go-header v0.4.2 // indirect
 	github.com/esimonov/ifshort v1.0.4 // indirect
 	github.com/ettle/strcase v0.1.1 // indirect

--- a/pkg/mocks/IdentityAPI_mocks.go
+++ b/pkg/mocks/IdentityAPI_mocks.go
@@ -35,16 +35,16 @@ func (m *MockIdentityAPI) EXPECT() *MockIdentityAPIMockRecorder {
 }
 
 // GenerateToken mocks base method.
-func (m *MockIdentityAPI) GenerateToken(arg0 context.Context, arg1, arg2, arg3 string) (string, error) {
+func (m *MockIdentityAPI) GenerateToken(arg0 context.Context, arg1, arg2, arg3, arg4 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateToken", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GenerateToken", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateToken indicates an expected call of GenerateToken.
-func (mr *MockIdentityAPIMockRecorder) GenerateToken(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockIdentityAPIMockRecorder) GenerateToken(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateToken", reflect.TypeOf((*MockIdentityAPI)(nil).GenerateToken), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateToken", reflect.TypeOf((*MockIdentityAPI)(nil).GenerateToken), arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -164,15 +164,16 @@ func convertToTypeSet(r *schema.Resource) *schema.Schema {
 
 // ValidateIAMVersion is a ValidateFunc for the "iam_version" field in the provider schema
 func ValidateIAMVersion(v interface{}, k string) ([]string, []error) {
-	// check that v is in iamVersionList
+	// This isn't strictly necessary, but it's a good idea to check that the input is a string
+	versionInput, ok := v.(string)
+	if !ok {
+		return []string{}, []error{fmt.Errorf("IAM version must be a string")}
+	}
+
+	// check that versionInput is in iamVersionList
 	found := false
 	for _, version := range iamVersionList {
-		versn, ok := v.(string)
-		if !ok {
-			return []string{}, []error{fmt.Errorf("IAM version must be a string")}
-		}
-
-		if string(version) == versn {
+		if string(version) == versionInput {
 			found = true
 			break
 		}
@@ -189,13 +190,14 @@ func ValidateIAMVersion(v interface{}, k string) ([]string, []error) {
 
 // ValidateServiceURL is a ValidateFunc for the "iam_service_url" field in the provider schema
 func ValidateServiceURL(v interface{}, k string) ([]string, []error) {
-	// check that v is a URL
-	_, ok := v.(string)
+	// check that v is a string, this should not be necessary but it's a good idea
+	serviceURL, ok := v.(string)
 	if !ok {
 		return []string{}, []error{fmt.Errorf("Service URL must be a string")}
 	}
 
-	_, err := url.ParseRequestURI(v.(string))
+	// check that serviceURL is a valid URL
+	_, err := url.ParseRequestURI(serviceURL)
 	if err != nil {
 		return []string{}, []error{fmt.Errorf("Service URL must be a valid URL")}
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -181,12 +181,12 @@ func TestValidateIAMVersion(t *testing.T) {
 	}{
 		{
 			name:     "valid IAM version GLCS",
-			version:  IAMVersionGLCS,
+			version:  string(IAMVersionGLCS),
 			hasError: false,
 		},
 		{
 			name:     "valid IAM version GLP",
-			version:  IAMVersionGLP,
+			version:  string(IAMVersionGLP),
 			hasError: false,
 		},
 		{
@@ -201,6 +201,39 @@ func TestValidateIAMVersion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, es := ValidateIAMVersion(tc.version, "iam_version")
+			if tc.hasError {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestValidateServiceURL(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name     string
+		url      string
+		hasError bool
+	}{
+		{
+			name:     "valid URL",
+			url:      "https://client.greenlake.hpe.com/api/iam",
+			hasError: false,
+		},
+		{
+			name:     "invalid URL",
+			url:      "invalid",
+			hasError: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		tc := testcase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, es := ValidateServiceURL(tc.url, "iam_service_url")
 			if tc.hasError {
 				assert.NotEmpty(t, es)
 			} else {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package provider
 
@@ -8,8 +8,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hewlettpackard/hpegl-provider-lib/pkg/registration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hewlettpackard/hpegl-provider-lib/pkg/registration"
 )
 
 func testResource() *schema.Resource {
@@ -167,6 +168,44 @@ func TestNewProviderFunc(t *testing.T) {
 			}()
 
 			NewProviderFunc(regs, providerConfigure)()
+		})
+	}
+}
+
+func TestValidateIAMVersion(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name     string
+		version  string
+		hasError bool
+	}{
+		{
+			name:     "valid IAM version GLCS",
+			version:  IAMVersionGLCS,
+			hasError: false,
+		},
+		{
+			name:     "valid IAM version GLP",
+			version:  IAMVersionGLP,
+			hasError: false,
+		},
+		{
+			name:     "invalid IAM version",
+			version:  "invalid",
+			hasError: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		tc := testcase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, es := ValidateIAMVersion(tc.version, "iam_version")
+			if tc.hasError {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
 		})
 	}
 }

--- a/pkg/token/httpclient/httpclient.go
+++ b/pkg/token/httpclient/httpclient.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package httpclient
 
@@ -33,11 +33,12 @@ func New(identityServiceURL string, vendedServiceClient bool, passedInToken stri
 	}
 }
 
-func (c *Client) GenerateToken(ctx context.Context, tenantID, clientID, clientSecret string) (string, error) {
+func (c *Client) GenerateToken(ctx context.Context, tenantID, clientID, clientSecret, iamVersion string) (string, error) {
 	// we don't have a passed-in token, so we need to actually generate a token
 	if c.passedInToken == "" {
 		if c.vendedServiceClient {
-			token, err := issuertoken.GenerateToken(ctx, tenantID, clientID, clientSecret, c.identityServiceURL, c.httpClient)
+			token, err := issuertoken.GenerateToken(
+				ctx, clientID, clientSecret, c.identityServiceURL, iamVersion, c.httpClient)
 
 			return token, err
 		}

--- a/pkg/token/httpclient/httpclient.go
+++ b/pkg/token/httpclient/httpclient.go
@@ -38,7 +38,7 @@ func (c *Client) GenerateToken(ctx context.Context, tenantID, clientID, clientSe
 	if c.passedInToken == "" {
 		if c.vendedServiceClient {
 			token, err := issuertoken.GenerateToken(
-				ctx, clientID, clientSecret, c.identityServiceURL, iamVersion, c.httpClient)
+				ctx, clientID, clientSecret, c.identityServiceURL, c.httpClient, iamVersion)
 
 			return token, err
 		}

--- a/pkg/token/httpclient/httpclient_test.go
+++ b/pkg/token/httpclient/httpclient_test.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 //nolint:structcheck
 package httpclient
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hewlettpackard/hpegl-provider-lib/pkg/provider"
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/token/identitytoken"
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/token/issuertoken"
-	"github.com/stretchr/testify/assert"
 )
 
 type testCaseIssuer struct {
@@ -205,7 +207,7 @@ func TestGenerateToken(t *testing.T) {
 
 		c = createTestClient(tc.url, "", tc.statusCode, tc.token, true)
 
-		token, err := c.GenerateToken(tc.ctx, "", "", "")
+		token, err := c.GenerateToken(tc.ctx, "", "", "", provider.IAMVersionGLCS)
 		if tc.err != nil {
 			assert.EqualError(t, err, tc.err.Error())
 		}
@@ -219,7 +221,7 @@ func TestGenerateToken(t *testing.T) {
 
 		c = createTestClient(tc.url, "", tc.statusCode, tc.token, false)
 
-		token, err := c.GenerateToken(tc.ctx, "", "", "")
+		token, err := c.GenerateToken(tc.ctx, "", "", "", provider.IAMVersionGLCS)
 		if tc.err != nil {
 			assert.EqualError(t, err, tc.err.Error())
 		}
@@ -232,7 +234,7 @@ func TestGenerateTokenPassedInToken(t *testing.T) {
 	t.Parallel()
 	c := createTestClient("", "testToken", http.StatusAccepted, nil, true)
 
-	token, err := c.GenerateToken(context.Background(), "", "", "")
+	token, err := c.GenerateToken(context.Background(), "", "", "", "")
 	assert.Equal(t, "testToken", token)
 	assert.NoError(t, err)
 }

--- a/pkg/token/httpclient/httpclient_test.go
+++ b/pkg/token/httpclient/httpclient_test.go
@@ -207,7 +207,7 @@ func TestGenerateToken(t *testing.T) {
 
 		c = createTestClient(tc.url, "", tc.statusCode, tc.token, true)
 
-		token, err := c.GenerateToken(tc.ctx, "", "", "", provider.IAMVersionGLCS)
+		token, err := c.GenerateToken(tc.ctx, "", "", "", string(provider.IAMVersionGLCS))
 		if tc.err != nil {
 			assert.EqualError(t, err, tc.err.Error())
 		}
@@ -221,7 +221,7 @@ func TestGenerateToken(t *testing.T) {
 
 		c = createTestClient(tc.url, "", tc.statusCode, tc.token, false)
 
-		token, err := c.GenerateToken(tc.ctx, "", "", "", provider.IAMVersionGLCS)
+		token, err := c.GenerateToken(tc.ctx, "", "", "", string(provider.IAMVersionGLCS))
 		if tc.err != nil {
 			assert.EqualError(t, err, tc.err.Error())
 		}

--- a/pkg/token/issuertoken/issuertoken.go
+++ b/pkg/token/issuertoken/issuertoken.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package issuertoken
 
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hewlettpackard/hpegl-provider-lib/pkg/provider"
 	tokenutil "github.com/hewlettpackard/hpegl-provider-lib/pkg/token/token-util"
 )
 
@@ -27,25 +28,26 @@ type TokenResponse struct {
 
 func GenerateToken(
 	ctx context.Context,
-	tenantID,
 	clientID,
 	clientSecret string,
 	identityServiceURL string,
+	iamVersion string,
 	httpClient tokenutil.HttpClient,
 ) (string, error) {
-	params := url.Values{}
-	params.Add("client_id", clientID)
-	params.Add("client_secret", clientSecret)
-	params.Add("grant_type", "client_credentials")
-	params.Add("scope", "hpe-tenant")
+	// Generate the parameters and URL for the request
+	params, clientURL, err := generateParamsAndURL(clientID, clientSecret, identityServiceURL, iamVersion)
+	if err != nil {
+		return "", err
+	}
 
-	url := fmt.Sprintf("%s/v1/token", identityServiceURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(params.Encode()))
+	// Create the request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, clientURL, strings.NewReader(params.Encode()))
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
+	// Execute the request, with retries
 	resp, err := tokenutil.DoRetries(func() (*http.Response, error) {
 		return httpClient.Do(req)
 	}, retryLimit)
@@ -72,4 +74,30 @@ func GenerateToken(
 	}
 
 	return token.AccessToken, nil
+}
+
+// generateParamsAndURL generates the parameters and URL for the request
+func generateParamsAndURL(clientID, clientSecret, identityServiceURL, iamVersion string) (url.Values, string, error) {
+	params := url.Values{}
+
+	// Add common parameters for an API Client
+	params.Add("client_id", clientID)
+	params.Add("client_secret", clientSecret)
+	params.Add("grant_type", "client_credentials")
+
+	// Add specific parameters and generate URL for the IAM version
+	var clientURL string
+	switch iamVersion {
+	case provider.IAMVersionGLCS:
+		params.Add("scope", "hpe-tenant")
+		clientURL = fmt.Sprintf("%s/v1/token", identityServiceURL)
+
+	case provider.IAMVersionGLP:
+		clientURL = identityServiceURL
+
+	default:
+		return nil, "", fmt.Errorf("invalid IAM version")
+	}
+
+	return params, clientURL, nil
 }

--- a/pkg/token/issuertoken/issuertoken.go
+++ b/pkg/token/issuertoken/issuertoken.go
@@ -31,8 +31,8 @@ func GenerateToken(
 	clientID,
 	clientSecret string,
 	identityServiceURL string,
-	iamVersion string,
 	httpClient tokenutil.HttpClient,
+	iamVersion string,
 ) (string, error) {
 	// Generate the parameters and URL for the request
 	params, clientURL, err := generateParamsAndURL(clientID, clientSecret, identityServiceURL, iamVersion)

--- a/pkg/token/issuertoken/issuertoken.go
+++ b/pkg/token/issuertoken/issuertoken.go
@@ -87,7 +87,7 @@ func generateParamsAndURL(clientID, clientSecret, identityServiceURL, iamVersion
 
 	// Add specific parameters and generate URL for the IAM version
 	var clientURL string
-	switch iamVersion {
+	switch provider.IAMVersion(iamVersion) {
 	case provider.IAMVersionGLCS:
 		params.Add("scope", "hpe-tenant")
 		clientURL = fmt.Sprintf("%s/v1/token", identityServiceURL)

--- a/pkg/token/issuertoken/issuertoken_test.go
+++ b/pkg/token/issuertoken/issuertoken_test.go
@@ -1,0 +1,49 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+package issuertoken
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hewlettpackard/hpegl-provider-lib/pkg/provider"
+)
+
+func TestGenerateParamsAndURL(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name       string
+		iamVersion string
+		hasError   bool
+	}{
+		{
+			name:       "valid IAM version GLCS",
+			iamVersion: provider.IAMVersionGLCS,
+			hasError:   false,
+		},
+		{
+			name:       "valid IAM version GLP",
+			iamVersion: provider.IAMVersionGLP,
+			hasError:   false,
+		},
+		{
+			name:       "invalid IAM version",
+			iamVersion: "invalid",
+			hasError:   true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		tc := testcase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := generateParamsAndURL("clientID", "clientSecret", "identityServiceURL", tc.iamVersion)
+			if tc.hasError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/pkg/token/issuertoken/issuertoken_test.go
+++ b/pkg/token/issuertoken/issuertoken_test.go
@@ -3,6 +3,7 @@
 package issuertoken
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,26 +11,43 @@ import (
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/provider"
 )
 
+func generateExpParams(iamVersion provider.IAMVersion) url.Values {
+	expParams := url.Values{}
+	expParams.Add("client_id", "clientID")
+	expParams.Add("client_secret", "clientSecret")
+	expParams.Add("grant_type", "client_credentials")
+	if iamVersion == provider.IAMVersionGLCS {
+		expParams.Add("scope", "hpe-tenant")
+	}
+
+	return expParams
+}
+
 func TestGenerateParamsAndURL(t *testing.T) {
 	t.Parallel()
+
 	testcases := []struct {
 		name       string
-		iamVersion string
+		iamVersion provider.IAMVersion
+		expParams  url.Values
 		hasError   bool
 	}{
 		{
 			name:       "valid IAM version GLCS",
 			iamVersion: provider.IAMVersionGLCS,
+			expParams:  generateExpParams(provider.IAMVersionGLCS),
 			hasError:   false,
 		},
 		{
 			name:       "valid IAM version GLP",
 			iamVersion: provider.IAMVersionGLP,
+			expParams:  generateExpParams(provider.IAMVersionGLP),
 			hasError:   false,
 		},
 		{
 			name:       "invalid IAM version",
 			iamVersion: "invalid",
+			expParams:  nil,
 			hasError:   true,
 		},
 	}
@@ -38,7 +56,8 @@ func TestGenerateParamsAndURL(t *testing.T) {
 		tc := testcase
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := generateParamsAndURL("clientID", "clientSecret", "identityServiceURL", tc.iamVersion)
+			params, _, err := generateParamsAndURL("clientID", "clientSecret", "identityServiceURL", string(tc.iamVersion))
+			assert.Equal(t, tc.expParams, params)
 			if tc.hasError {
 				assert.NotNil(t, err)
 			} else {

--- a/pkg/token/serviceclient/handler.go
+++ b/pkg/token/serviceclient/handler.go
@@ -5,7 +5,6 @@ package serviceclient
 import (
 	"context"
 	"errors"
-	"github.com/davecgh/go-spew/spew"
 	"net"
 	"time"
 
@@ -153,7 +152,6 @@ func (h *Handler) retrieveToken() common.Result {
 		}
 
 		// If token is about to expire in TimeToTokenExpiry seconds or less generate a new one
-		spew.Dump(tokenDetails)
 		if tokenDetails.Expiry-now <= common.TimeToTokenExpiry {
 			token, retry, err := h.generateToken()
 			if retry {

--- a/pkg/token/serviceclient/handler_test.go
+++ b/pkg/token/serviceclient/handler_test.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package serviceclient_test
 
@@ -103,7 +103,7 @@ func TestHandler(t *testing.T) {
 			assert.NoError(t, err)
 
 			testToken := generateTestToken(600)
-			mock.EXPECT().GenerateToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testToken, tc.err).MaxTimes(8)
+			mock.EXPECT().GenerateToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testToken, tc.err).MaxTimes(8)
 
 			handler, err := serviceclient.NewHandler(d, serviceclient.WithIdentityAPI(mock))
 			assert.NoError(t, err)


### PR DESCRIPTION
In this PR we add support for GLP IAM API Clients.  We retain support for GLCS API Clients.  We also retain support for "non-api vended" GLCS API Clients for backwards compatibility.

We've added a new provider parameter "iam_version" with the corresponding env-var HPEGL_IAM_VERSION to designate which version of IAM is being used:
- glcs
- glp

The default value of this parameter is glcs.  We've added a function to validate the value of "iam_version".

We've updated the "description" field for "api_vended_service_client" and "tenant_id" in light of the support for GLP IAM.

The issuertoken package has been modified to generate the correct URL and the correct set of http request parameters depending on which type of IAM is being used.

We've had to update various unit-tests and the generated mocks.

Signed-off-by: Eamonn O'Toole <eamonn.otoole@hpe.com>