### PR TITLE
Add retry on 502 return code

### DIFF
--- a/pkg/token/token-util/token-util.go
+++ b/pkg/token/token-util/token-util.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package tokenutil
 
@@ -134,7 +134,8 @@ func ManageHTTPErrorCodes(resp *http.Response, clientID string) error {
 }
 
 func isStatusRetryable(statusCode int) bool {
-	if statusCode == http.StatusInternalServerError || statusCode == http.StatusTooManyRequests {
+	if statusCode == http.StatusInternalServerError || statusCode == http.StatusTooManyRequests ||
+		statusCode == http.StatusBadGateway {
 		return true
 	}
 

--- a/pkg/token/token-util/token-util_test.go
+++ b/pkg/token/token-util/token-util_test.go
@@ -158,13 +158,22 @@ func TestDoRetries(t *testing.T) {
 			responseStatus: http.StatusTooManyRequests,
 		},
 		{
-			name: "status 502 no retry",
+			name: "status 502",
 			call: func() (*http.Response, error) {
 				totalRetries++
 
 				return &http.Response{StatusCode: http.StatusBadGateway}, nil
 			},
 			responseStatus: http.StatusBadGateway,
+		},
+		{
+			name: "status 403 no retry",
+			call: func() (*http.Response, error) {
+				totalRetries++
+
+				return &http.Response{StatusCode: http.StatusForbidden}, nil
+			},
+			responseStatus: http.StatusForbidden,
 		},
 		{
 			name: "no url",
@@ -184,8 +193,8 @@ func TestDoRetries(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.responseStatus, resp.StatusCode)
 
-				// only 429 and 500 status codes should retry
-				if tc.responseStatus == http.StatusBadGateway {
+				// only 429, 500 and 502 status codes should retry
+				if tc.responseStatus == http.StatusForbidden {
 					assert.Equal(t, 1, totalRetries)
 				} else {
 					assert.Equal(t, 2, totalRetries)


### PR DESCRIPTION
In this PR we add the 502 (Bad Gateway) to the list of http return codes that will result in a retry.  This is to alleviate errors seen in some runtime environments.