### PR TITLE
Create new http request on each retry

### DIFF
--- a/pkg/token/httpclient/httpclient_test.go
+++ b/pkg/token/httpclient/httpclient_test.go
@@ -126,7 +126,7 @@ func setTestCase() ([]testCaseIssuer, []testCaseIdentity) {
 				name: "no context",
 				url:  "https://hpe-greenlake-tenant.okta.com/oauth2/default",
 				ctx:  nil,
-				err:  errors.New("net/http: nil Context"),
+				err:  errors.New("network error in post to get token"),
 			},
 			{
 				name:       "status code 400",

--- a/pkg/token/token-util/token-util.go
+++ b/pkg/token/token-util/token-util.go
@@ -89,6 +89,7 @@ func DoRetries(call func() (*http.Response, error), retries int) (*http.Response
 			break
 		}
 
+		log.Printf("Retrying request, retries left: %v", retries)
 		time.Sleep(3 * time.Second)
 		retries--
 	}


### PR DESCRIPTION
In this PR we change the behaviour in issuertoken to:
- create a new http request object on each retry
- set Close on each request so that the underlying tcp connection is always closed

We do this because we are seeing issues with retries on 502 responses from IAM.  Retries don't seem to make any difference, in other words we continue to receive 502 responses on each retry.

We also log each retry so that the terraform provider logs will record the retries.