### PR TITLE
Fix request context cancel race when reading response

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 name: Trivy
 on:
   pull_request:
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Trivy vulnerability scanner (go.mod)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
           hide-progress: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/hewlettpackard/hpegl-provider-lib
 
-go 1.21
+go 1.22.1
+
 toolchain go1.22.5
 
 require (

--- a/pkg/token/httpclient/httpclient.go
+++ b/pkg/token/httpclient/httpclient.go
@@ -22,7 +22,7 @@ type Client struct {
 
 // New creates a new identity Client object
 func New(identityServiceURL string, vendedServiceClient bool, passedInToken string) *Client {
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{Timeout: 120 * time.Second}
 	identityServiceURL = strings.TrimRight(identityServiceURL, "/")
 
 	return &Client{

--- a/pkg/token/token-util/token-util.go
+++ b/pkg/token/token-util/token-util.go
@@ -76,7 +76,12 @@ func DecodeAccessToken(rawToken string) (Token, error) {
 	return token, nil
 }
 
-func DoRetries(ctx context.Context, call func(ctx context.Context) (*http.Request, *http.Response, error), retries int) (*http.Response, error) {
+func DoRetries(
+	ctx context.Context,
+	cancelFuncs *[]context.CancelFunc,
+	call func(ctx context.Context) (*http.Request, *http.Response, error),
+	retries int,
+) (*http.Response, error) {
 	var req *http.Request
 	var resp *http.Response
 	var err error
@@ -91,7 +96,9 @@ func DoRetries(ctx context.Context, call func(ctx context.Context) (*http.Reques
 
 		// Create a new context with a timeout
 		ctxWithTimeout, cancel := createContextWithTimeout(ctx)
-		defer cancel()
+
+		// Add the cancel function to the list of cancel functions
+		*cancelFuncs = append(*cancelFuncs, cancel)
 
 		// Execute the request
 		req, resp, err = call(ctxWithTimeout)


### PR DESCRIPTION
We had a race between request context cancellation and the reading of the corresponding response.  In some circumstances the request context was cancelled before the corresponding response body was read, which resulted in a "context canceled" error.

To fix this we create a []context.CancelFunc slice in the routines that call into token-util/DoRetries and we pass-in a pointer to this slice. Then within DoRetries we append each created cancel to this slice.  When we return from DoRetries we defer a function to call the cancel functions.  In this way we guarantee that we read the response before the corresponding request context is cancelled which fixes the race.

We pass-in a slice to ensure that we still comply with the httpclient Do "interface".

We've adapted the relevant unit-tests, and also incresed the base httpclient timeout to 120s to allow sufficient time for all retries to be executed.

We had to fix the trivy scan GH action to pull the latest version of the
action as opposed to master.

Signed-off-by: Eamonn O'Toole <eamonn.otoole@hpe.com>

