### PR TITLE
Turn on GHA dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
   registries: []
   schedule:
     interval: daily
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  registries:
+    - github-hpe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
         go: [ '1.21' ]
     name: Go ${{ matrix.go }} CI test
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - run: go version

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (go.mod)
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
Bump checkout and setup-go actions to newer versions. I think this may be affecting the CI issue: 
```
golangci-lint run ./...
level=error msg="Running error: context loading failed: no go files to analyze" 
```