### PR TITLE
Allow insecure IAM endpoint connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/hewlettpackard/hpegl-provider-lib
 
-go 1.22.1
+go 1.23.0
+
 toolchain go1.24.1
 
 require (

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 package provider
 
@@ -108,6 +108,14 @@ func Schema() map[string]*schema.Schema {
 		ValidateFunc: ValidateIAMVersion,
 		Description: `The IAM version to be used.  Can be set by HPEGL_IAM_VERSION env-var. Valid values are: 
 			` + fmt.Sprintf("%v", iamVersionList) + `The default is ` + string(IAMVersionGLCS) + `.`,
+	}
+
+	providerSchema["iam_insecure"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		DefaultFunc: schema.EnvDefaultFunc("HPEGL_IAM_INSECURE", false),
+		Description: `Don't verify the TLS certificate of the IAM service.  This is not recommended. Defaults to "false"
+			i.e. the TLS certificate is verified.  The value can be set using the HPEGL_IAM_INSECURE env-var.`,
 	}
 
 	providerSchema["api_vended_service_client"] = &schema.Schema{

--- a/pkg/token/httpclient/httpclient_test.go
+++ b/pkg/token/httpclient/httpclient_test.go
@@ -81,7 +81,7 @@ func createTestClient(
 	token interface{},
 	vendedServiceClient bool,
 ) *Client {
-	c := New(identityServiceURL, vendedServiceClient, passedInToken)
+	c := New(identityServiceURL, true, vendedServiceClient, passedInToken)
 	if token == nil {
 		c.httpClient = &testHTTPClient{
 			statusCode: statusCode,

--- a/pkg/token/serviceclient/handler.go
+++ b/pkg/token/serviceclient/handler.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 package serviceclient
 
@@ -32,6 +32,7 @@ type Handler struct {
 	clientSecret        string
 	iamVersion          string
 	vendedServiceClient bool
+	iamInsecure         bool
 	numRetries          int
 	client              IdentityAPI
 	resultCh            chan common.Result
@@ -63,6 +64,7 @@ func NewHandler(d resourceData, opts ...CreateOpt) (common.TokenChannelInterface
 	// set Handler fields
 	h.iamServiceURL = d.Get("iam_service_url").(string)
 	h.iamVersion = d.Get("iam_version").(string)
+	h.iamInsecure = d.Get("iam_insecure").(bool)
 	h.tenantID = d.Get("tenant_id").(string)
 	h.clientID = d.Get("user_id").(string)
 	h.clientSecret = d.Get("user_secret").(string)
@@ -71,7 +73,7 @@ func NewHandler(d resourceData, opts ...CreateOpt) (common.TokenChannelInterface
 	// get passed-in token, if present
 	passedInToken := d.Get("iam_token").(string)
 
-	h.client = httpc.New(h.iamServiceURL, h.vendedServiceClient, passedInToken)
+	h.client = httpc.New(h.iamServiceURL, h.iamInsecure, h.vendedServiceClient, passedInToken)
 
 	// run overrides
 	for _, opt := range opts {


### PR DESCRIPTION
Some customer environments use custom certs for the IAM endpoint, and for testing and demonstration purposes it is convenient to skip cert checking for the IAM endpoint.  In this PR we add a new provider block boolean attribute "iam_insecure" which defaults to false.  Setting it to "true" will disable cert checking for the IAM endpoint.  The value of this attribute can also be set by the "HPEGL_IAM_INSECURE" env-var.